### PR TITLE
解决重复生成时结果变化问题

### DIFF
--- a/model/DemoScara.m
+++ b/model/DemoScara.m
@@ -1,0 +1,31 @@
+function rbt_config = DemoScara()
+
+%% 7 joint angle
+syms q1 q2 q3 q4 real;
+pi_ = sym(pi);
+
+%% geoetric parameter
+d1 = 0.1;
+d2 = 0.1;
+d3 = 0.1;
+
+% define link number used to create joint tree
+L_b = 0;
+L_1 = 1;
+L_2 = 2;
+L_3 = 3;
+L_4 = 4;
+
+% define spring
+dlN = NaN;
+
+
+rbt_config = {
+% Joint number|prev link|succ links     |screw axis unit direction  |rs                 |M_R                    |theta      |h    |link inertia     |spring 
+    L_b,          -1,       L_1,         [0;0;0],                  [0;0;0],             eye(3),                sym(0),       0,     false,         dlN;
+    L_1,          L_b,      L_2,         [0;0;1],                  [0;0;0],             eye(3),                q1,           0,     true,          dlN;
+    L_2,          L_1,      L_3,         [0;0;1],                  [d1;0;0],            eye(3),                q2,           0,     true,          dlN; 
+    L_3,          L_2,      L_4,         [0;0;1],                  [d1+d2;0;0],         eye(3),                q3,           0,     true,          dlN;
+    L_4,          L_3,      [],         [0;0;1],                   [d1+d2;0;-d3],       eye(3),                q4,           inf,   true,          dlN;
+};
+end

--- a/run_Scara.m
+++ b/run_Scara.m
@@ -1,0 +1,29 @@
+clear
+clc
+close all 
+%%
+gravity_vec = [0, 0, -9.8015];
+
+rbt_config = DemoScara;
+rbt = struct();
+rbt.rbt_df = DefineRobot('DemoScara',rbt_config);
+rbt.geom = GeometryCalculation(rbt.rbt_df);
+rbt.dyn = Dynamics(rbt.rbt_df, rbt.geom, gravity_vec);
+rbt.base = DynamicBaseParamCalc(rbt.rbt_df, rbt.dyn);
+
+%% save output
+out_path = "output/";
+[status, msg, msgID] = mkdir('output');
+addpath(out_path);
+
+save output/rbt;
+
+%% H matrix for prime parameter
+make_H_function(rbt);
+
+%% Y matrix for base parameter 
+make_Y_function(rbt);
+
+%% MCG matrix : M(q, P)  C(q, dq, P)  G(q, P) 
+result_MCG = make_MCG_function(rbt); 
+

--- a/src/DynamicBaseParamCalc.m
+++ b/src/DynamicBaseParamCalc.m
@@ -40,7 +40,7 @@ function [r, P_X, P, Kd] = find_dyn_param_deps(rbt_df, dyn)
     Z = zeros(dof * sample_num, param_num);
     
     funcHandle = matlabFunction(vpa(dyn.H),'Vars', {rbt_df.coordinates', rbt_df.d_coordinates', rbt_df.dd_coordinates'});
-    
+    rng(123);   % 固定随机数种子，确保每次生成结果相同
     for i = 1:sample_num
         q = rand([dof, 1])*2*pi - pi;
         dq = rand([dof, 1])*2*pi - pi;

--- a/src/make_MCG_function.m
+++ b/src/make_MCG_function.m
@@ -7,7 +7,7 @@ tic
 disp('Creating M C G matrix ...');
 model_name = rbt.rbt_df.name;
 P = sym('p', [rbt.base.base_num,1], 'real');
-reresult.base_param_symbol = P;
+result.base_param_symbol = P;
 
 DOF = size(rbt.base.H_b, 1);
 Y = rbt.base.H_b;
@@ -18,9 +18,9 @@ g = subs(tau, [rbt.rbt_df.d_coordinates, rbt.rbt_df.dd_coordinates], [zeros(size
 mc = tau - g;
 m = subs(mc, [rbt.rbt_df.d_coordinates], [zeros(size(rbt.rbt_df.d_coordinates))]);
 c = mc - m;
-reresult.g = g;
-reresult.m = m;
-reresult.c = c;
+result.g = g;
+result.m = m;
+result.c = c;
 
 
 %% make static part
@@ -32,12 +32,12 @@ for v = vars
     end
 end
 [base2static_part, ~] = equationsToMatrix(static_part_vars, P);
-reresult.static_param_symbol = static_part_vars;
-reresult.base_param2static_param = base2static_part;
+result.static_param_symbol = static_part_vars;
+result.base_param2static_param = base2static_part;
 [Gmat, ~] = equationsToMatrix(g, static_part_vars);
-reresult.Gmat = simplify(Gmat);
+result.Gmat = simplify(Gmat);
 
-matlabFunction(reresult.Gmat, 'File',out_path+model_name+'_G_mat', 'Vars', {rbt.rbt_df.coordinates'});
+matlabFunction(result.Gmat, 'File',out_path+model_name+'_G_mat', 'Vars', {rbt.rbt_df.coordinates'});
 disp('function writen into '+ out_path + model_name + '_G_mat.m')
 
 matlabFunction(base2static_part, 'File',out_path+model_name+'_base_param2static_param');
@@ -57,6 +57,7 @@ for k = 1:DOF
     M_col = subs(m, [rbt.rbt_df.dd_coordinates], [one_hot']);
     M = [M, M_col];
 end
+result.M = M;
 matlabFunction(vpa(M), 'File',out_path+model_name+'_M_func', 'Vars', {rbt.rbt_df.coordinates', P});
 disp('function writen into '+ out_path + model_name + '_M_func.m')
 
@@ -74,6 +75,7 @@ for i = 1:DOF
         end
     end
 end
+result.C = C;
 rbt.C_b_func = matlabFunction(vpa(C), 'File',out_path+model_name+'_C_func', 'Vars', {rbt.rbt_df.coordinates', rbt.rbt_df.d_coordinates', P});
 disp('function writen into '+ out_path + model_name + '_C_func.m')
 


### PR DESCRIPTION
在最小惯性参数集分解时使用了数值计算技巧，存在一定随机性，重复运行同一个模型，可能会导致最小惯性参数集的排布顺序不同，固定随机数种子以解决这个问题。